### PR TITLE
Fix size calculation in flush

### DIFF
--- a/dma_uart.cpp
+++ b/dma_uart.cpp
@@ -94,7 +94,7 @@ uint16_t DmaUart::write(const uint8_t* data, uint16_t length) {
 }
 
 void DmaUart::flush() {
-  uint size = (tx_dma_index_ < tx_user_index_)
+  uint size = (tx_dma_index_ <= tx_user_index_)
                   ? (tx_user_index_ - tx_dma_index_)
                   : (kTxBuffLength + tx_user_index_ - tx_dma_index_);
   // Size check


### PR DESCRIPTION
If dma index and user index are equal (after write and flush), and flush is called again, size is incorrectly calculated as kTxBuffLength and the full buffer is transmitted. Instead, size should be zero and return called.