### PR TITLE
Fix illegal write in read

### DIFF
--- a/dma_uart.cpp
+++ b/dma_uart.cpp
@@ -137,18 +137,25 @@ uint16_t DmaUart::read(uint8_t* data, uint16_t length) {
   available = (rx_user_index_ <= rx_dma_index_)
                   ? (rx_dma_index_ - rx_user_index_)
                   : (kTxBuffLength + rx_dma_index_ - rx_user_index_);
-  if (length <= available) {
-    if (rx_user_index_ < rx_dma_index_) {
-      memcpy(data, &rx_buffer_[rx_user_index_], length);
-    } else {
-      uint16_t left = kRxBuffLength - rx_user_index_;
-      memcpy(data, &rx_buffer_[rx_user_index_], left);
-      memcpy(&data[left], rx_buffer_, length - left);
-    }
-    rx_user_index_ = (rx_user_index_ + length) & (kRxBuffLength - 1);
-  } else {
+  
+  if (available < length) {
+    // read as much as we have
+    length = available;
+  }
+  
+  if (length == 0) {
     return 0;
   }
+
+  if (rx_user_index_ < rx_dma_index_) {
+    memcpy(data, &rx_buffer_[rx_user_index_], length);
+  } else {
+    uint16_t left = kRxBuffLength - rx_user_index_;
+    memcpy(data, &rx_buffer_[rx_user_index_], left);
+    memcpy(&data[left], rx_buffer_, length - left);
+  }
+  rx_user_index_ = (rx_user_index_ + length) & (kRxBuffLength - 1);
+
   return length;
 }
 

--- a/dma_uart.cpp
+++ b/dma_uart.cpp
@@ -151,8 +151,17 @@ uint16_t DmaUart::read(uint8_t* data, uint16_t length) {
     memcpy(data, &rx_buffer_[rx_user_index_], length);
   } else {
     uint16_t left = kRxBuffLength - rx_user_index_;
+
+    if (left > length) {
+      // limit to target buffer size!
+      left = length;
+    }
+
     memcpy(data, &rx_buffer_[rx_user_index_], left);
-    memcpy(&data[left], rx_buffer_, length - left);
+
+    if (length > left) {
+      memcpy(&data[left], rx_buffer_, length - left);
+    }
   }
   rx_user_index_ = (rx_user_index_ + length) & (kRxBuffLength - 1);
 


### PR DESCRIPTION
If left is still larger than supplied buffer, we will write after the buffer. So add a limitation check.